### PR TITLE
Add Facebook authentication and some basic roles

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -36,4 +36,5 @@ dependencies {
     compile 'org.apache.commons:commons-lang3:3.4'
     compile 'com.firebase:firebase-client-android:2.3.1'
     compile 'com.firebaseui:firebase-ui:0.3.1'
+    compile 'com.facebook.android:facebook-android-sdk:[4,5)'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -1,16 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="hoopray.safetypongandroid"
-          xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest
+    package="hoopray.safetypongandroid"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
+        android:name=".SafetyApplication"
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme"
-        android:name=".SafetyApplication">
+        android:theme="@style/AppTheme">
+
+        <meta-data
+            android:name="com.facebook.sdk.ApplicationId"
+            android:value="@string/facebook_app_id"/>
+
         <activity
             android:name=".MainActivity"
             android:label="@string/ladder"
@@ -21,14 +27,25 @@
                 <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <activity android:name=".ChallengeActivity" android:theme="@style/NoBar"/>
-        <activity android:name=".GameResultsActivity" android:theme="@style/NoBar"/>
+        <activity
+            android:name=".ChallengeActivity"
+            android:theme="@style/NoBar"/>
+        <activity
+            android:name=".GameResultsActivity"
+            android:theme="@style/NoBar"/>
 
         <activity
             android:name=".LeagueActivity"
             android:label="@string/title_activity_league"
             android:theme="@style/AppTheme.NoActionBar">
         </activity>
+
+        <activity
+            android:name="com.facebook.FacebookActivity"
+            android:configChanges=
+                "keyboard|keyboardHidden|screenLayout|screenSize|orientation"
+            android:label="@string/app_name"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/hoopray/safetypongandroid/FirebaseConstants.java
+++ b/app/src/main/java/hoopray/safetypongandroid/FirebaseConstants.java
@@ -10,6 +10,13 @@ public class FirebaseConstants
     public static final String NAME = "name";
     public static final String PASSWORD = "password";
 
+    public static final String USERS = "users";
+    public static final String ROLES = "roles";
+    public static final String OWNER = "owner";
+    public static final String ADMIN = "admin";
+    public static final String PLAYER = "player";
+    public static final String IMAGE = "image";
+
     public static final String PLAYERS = "players";
 
     public static final String GAMES = "games";

--- a/app/src/main/java/hoopray/safetypongandroid/FirebaseHelper.java
+++ b/app/src/main/java/hoopray/safetypongandroid/FirebaseHelper.java
@@ -1,10 +1,17 @@
 package hoopray.safetypongandroid;
 
+import com.firebase.client.AuthData;
 import com.firebase.client.Firebase;
 
 import static hoopray.safetypongandroid.FirebaseConstants.FIREBASE_PATH;
 import static hoopray.safetypongandroid.FirebaseConstants.GAMES;
+import static hoopray.safetypongandroid.FirebaseConstants.LEAGUES;
+import static hoopray.safetypongandroid.FirebaseConstants.NAME;
+import static hoopray.safetypongandroid.FirebaseConstants.OWNER;
 import static hoopray.safetypongandroid.FirebaseConstants.PLAYERS;
+import static hoopray.safetypongandroid.FirebaseConstants.ROLES;
+import static hoopray.safetypongandroid.FirebaseConstants.USERS;
+import static hoopray.safetypongandroid.FirebaseConstants.IMAGE;
 
 /**
  * @author Dominic Murray 5/04/2016.
@@ -23,6 +30,30 @@ public class FirebaseHelper
 		safetyPong.setValue(game);
 	}
 
+	public static void createLeague(String key, String leagueName, String password)
+	{
+		Firebase leagueRef = new Firebase(FirebaseConstants.FIREBASE_PATH + '/' + LEAGUES).child(key);
+		League league = new League();
+		league.setName(leagueName);
+		league.setPassword(password);
+		leagueRef.setValue(league);
+
+		// Set owner role
+		Firebase firebase = new Firebase(FIREBASE_PATH);
+		String authId = firebase.getAuth().getUid();
+		leagueRef.child(ROLES).child(authId).setValue(OWNER);
+
+		// Set add league to users leagues
+		firebase.child(USERS).child(authId).child(LEAGUES).child(key).setValue(leagueName);
+	}
+
+	public static void updateUsersDetails(AuthData authData)
+	{
+		Firebase firebase = new Firebase(FIREBASE_PATH).child(USERS).child(authData.getUid());
+		firebase.child(NAME).setValue(authData.getProviderData().get("displayName"));
+		firebase.child(IMAGE).setValue(authData.getProviderData().get("profileImageURL"));
+	}
+
 	public static Firebase getPlayerReferences()
 	{
 		return new Firebase(FIREBASE_PATH + '/' + PLAYERS + '/' + SafetyApplication.getInstance().currentLeagueKey);
@@ -31,5 +62,11 @@ public class FirebaseHelper
 	public static Firebase getGamesReferences()
 	{
 		return new Firebase(FIREBASE_PATH + '/' + GAMES + '/' + SafetyApplication.getInstance().currentLeagueKey);
+	}
+
+	public static Firebase getPlayerLeaguesListReference()
+	{
+		Firebase ref = new Firebase(FIREBASE_PATH);
+		return ref.child(USERS).child(ref.getAuth().getUid()).child(LEAGUES);
 	}
 }

--- a/app/src/main/java/hoopray/safetypongandroid/LeagueListFragment.java
+++ b/app/src/main/java/hoopray/safetypongandroid/LeagueListFragment.java
@@ -1,0 +1,78 @@
+package hoopray.safetypongandroid;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.support.v4.app.Fragment;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import com.firebase.client.Firebase;
+import com.firebase.ui.FirebaseRecyclerAdapter;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+import hoopray.safetypongandroid.firebaseviewholders.SingleLineViewHolder;
+
+/**
+ * @author Dominic Murray 9/04/2016.
+ */
+public class LeagueListFragment extends Fragment
+{
+    @Bind(R.id.recyclerview)
+    RecyclerView recyclerView;
+
+    private FirebaseRecyclerAdapter<String, SingleLineViewHolder> adapter;
+
+    @Nullable
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+    {
+        View view = inflater.inflate(R.layout.recyclerview, container, false);
+        ButterKnife.bind(this, view);
+
+        recyclerView.setHasFixedSize(true);
+        recyclerView.setLayoutManager(new LinearLayoutManager(getActivity()));
+
+        Firebase ref = FirebaseHelper.getPlayerLeaguesListReference();
+        adapter = new FirebaseRecyclerAdapter<String, SingleLineViewHolder>(String.class, android.R.layout.simple_list_item_2, SingleLineViewHolder.class, ref)
+        {
+            @Override
+            protected void populateViewHolder(SingleLineViewHolder holder, String game, int i)
+            {
+                holder.itemView.setOnClickListener(new ItemClickListener(i));
+                holder.text.setText(game);
+            }
+        };
+        recyclerView.setAdapter(adapter);
+
+        return view;
+    }
+
+    @Override
+    public void onDestroy()
+    {
+        super.onDestroy();
+        adapter.cleanup();
+    }
+
+    private class ItemClickListener implements View.OnClickListener
+    {
+        private int position;
+
+        public ItemClickListener(int position)
+        {
+            this.position = position;
+        }
+
+        @Override
+        public void onClick(View view)
+        {
+            SafetyApplication.getInstance().currentLeagueKey = adapter.getRef(position).getKey();
+            startActivity(new Intent(getActivity(), LeagueActivity.class));
+        }
+    }
+}

--- a/app/src/main/java/hoopray/safetypongandroid/MainActivity.java
+++ b/app/src/main/java/hoopray/safetypongandroid/MainActivity.java
@@ -1,30 +1,142 @@
 package hoopray.safetypongandroid;
 
+import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
-import android.text.TextUtils;
 import android.transition.Explode;
-import butterknife.ButterKnife;
-import butterknife.OnClick;
+import android.view.View;
+
+import com.facebook.AccessToken;
+import com.facebook.CallbackManager;
+import com.facebook.FacebookCallback;
+import com.facebook.FacebookException;
+import com.facebook.appevents.AppEventsLogger;
+import com.facebook.login.LoginResult;
+import com.facebook.login.widget.LoginButton;
+import com.firebase.client.AuthData;
+import com.firebase.client.Firebase;
+import com.firebase.client.FirebaseError;
 
 public class MainActivity extends AppCompatActivity
 {
-	@Override
-	protected void onCreate(Bundle savedInstanceState)
-	{
-		super.onCreate(savedInstanceState);
-		setContentView(R.layout.main_activity);
+    private CallbackManager callbackManager;
+    private ProgressDialog progressDialog;
+    private LoginButton loginButton;
 
-		if(SafetyApplication.is21Plus)
-			getWindow().setExitTransition(new Explode());
-		Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
-		setSupportActionBar(toolbar);
+    @Override
+    protected void onCreate(Bundle savedInstanceState)
+    {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.main_activity);
 
-		getSupportFragmentManager().beginTransaction().replace(R.id.container, new LeagueLoginFragment()).commit();
+        if(SafetyApplication.is21Plus)
+            getWindow().setExitTransition(new Explode());
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        setSupportActionBar(toolbar);
 
-		if(!TextUtils.isEmpty(SafetyApplication.getInstance().currentLeagueKey))
-			startActivity(new Intent(this, LeagueActivity.class));
-	}
+        loginButton = (LoginButton) findViewById(R.id.login_button);
+        loginButton.setReadPermissions("public_profile");
+        // Other app specific specialization
+        callbackManager = CallbackManager.Factory.create();
+
+        AccessToken token = AccessToken.getCurrentAccessToken();
+        if(token != null)
+        {
+            loginButton.setVisibility(View.GONE);
+            startAuthProcess(token);
+        }
+
+        // Callback registration
+        loginButton.registerCallback(callbackManager, new FacebookCallback<LoginResult>()
+        {
+            @Override
+            public void onSuccess(LoginResult loginResult)
+            {
+                startAuthProcess(loginResult.getAccessToken());
+            }
+
+            @Override
+            public void onCancel()
+            {
+            }
+
+            @Override
+            public void onError(FacebookException exception)
+            {
+            }
+        });
+    }
+
+    @Override
+    protected void onResume()
+    {
+        super.onResume();
+        AppEventsLogger.activateApp(this);
+    }
+
+    @Override
+    protected void onPause()
+    {
+        super.onPause();
+        AppEventsLogger.deactivateApp(this);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        super.onActivityResult(requestCode, resultCode, data);
+        callbackManager.onActivityResult(requestCode, resultCode, data);
+    }
+
+    private void startAuthProcess(AccessToken token)
+    {
+        progressDialog = new ProgressDialog(this);
+        progressDialog.show();
+
+        Firebase ref = new Firebase(FirebaseConstants.FIREBASE_PATH);
+        if(token == null)
+        {
+            ref.unauth();
+            return;
+        }
+
+        ref.authWithOAuthToken("facebook", token.getToken(), new FirebaseAuthHandler());
+    }
+
+    private void handleAuthResultsReceived()
+    {
+        if(progressDialog != null)
+        {
+            progressDialog.dismiss();
+            progressDialog = null;
+        }
+    }
+
+    private class FirebaseAuthHandler implements Firebase.AuthResultHandler
+    {
+        @Override
+        public void onAuthenticated(AuthData authData)
+        {
+            FirebaseHelper.updateUsersDetails(authData);
+
+            runOnUiThread(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    getSupportFragmentManager().beginTransaction().replace(R.id.container, new LeagueListFragment()).commit();
+                    loginButton.setVisibility(View.GONE);
+                    handleAuthResultsReceived();
+                }
+            });
+        }
+
+        @Override
+        public void onAuthenticationError(FirebaseError firebaseError)
+        {
+            handleAuthResultsReceived();
+        }
+    }
 }

--- a/app/src/main/java/hoopray/safetypongandroid/SafetyApplication.java
+++ b/app/src/main/java/hoopray/safetypongandroid/SafetyApplication.java
@@ -3,6 +3,7 @@ package hoopray.safetypongandroid;
 import android.app.Application;
 import android.os.Build;
 
+import com.facebook.FacebookSdk;
 import com.firebase.client.Firebase;
 
 /**
@@ -23,6 +24,7 @@ public class SafetyApplication extends Application
 		super.onCreate();
 		app = this;
 		Firebase.setAndroidContext(this);
+		FacebookSdk.sdkInitialize(this);
 //        Firebase safetyPong = firebase.child("leagues").child(UUID.randomUUID().toString());
 //        League league = new League("SafetyPong", "SafetyWow");
 //        safetyPong.setValue(league);

--- a/app/src/main/java/hoopray/safetypongandroid/firebaseviewholders/SingleLineViewHolder.java
+++ b/app/src/main/java/hoopray/safetypongandroid/firebaseviewholders/SingleLineViewHolder.java
@@ -1,0 +1,24 @@
+package hoopray.safetypongandroid.firebaseviewholders;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import butterknife.Bind;
+import butterknife.ButterKnife;
+
+/**
+ * @author Dominic Murray 9/04/2016.
+ */
+public class SingleLineViewHolder extends RecyclerView.ViewHolder
+{
+    @Bind(android.R.id.text1)
+    public TextView text;
+
+
+    public SingleLineViewHolder(View itemView)
+    {
+        super(itemView);
+        ButterKnife.bind(this, itemView);
+    }
+}

--- a/app/src/main/res/layout/main_activity.xml
+++ b/app/src/main/res/layout/main_activity.xml
@@ -26,6 +26,15 @@
         android:id="@+id/container"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:background="@color/colorPrimaryDark"/>
+        android:background="@color/colorPrimaryDark"
+        android:layout_marginTop="?attr/actionBarSize"/>
+
+    <com.facebook.login.widget.LoginButton
+        android:id="@+id/login_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginTop="30dp"
+        android:layout_marginBottom="30dp" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/layout/recyclerview.xml
+++ b/app/src/main/res/layout/recyclerview.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v7.widget.RecyclerView android:id="@+id/recyclerview"
+                                        xmlns:android="http://schemas.android.com/apk/res/android"
+                                        android:layout_width="match_parent"
+                                        android:layout_height="match_parent"
+                                        android:background="@android:color/white"/>

--- a/app/src/main/res/values/untranslatable-strings.xml
+++ b/app/src/main/res/values/untranslatable-strings.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+    <string name="facebook_app_id">154016564993393</string>
     <string name="floating_card">floating_card</string>
     <string name="background">background</string>
     <string name="first_challenger">first challenger</string>


### PR DESCRIPTION
When a user creates a league they are added as the owner for that league. Also put a list of leagues into the user so we can use that to show a list of leagues they participate in. Seemed easier to duplicate that into the user data because there wouldn't be an easy way with Firebase to query a list of leagues that a user is involved in.
